### PR TITLE
DX11 Portrait orientation fullscreen scaling issue - workaround

### DIFF
--- a/DX11_fullscreen_portrait_repro.cpp
+++ b/DX11_fullscreen_portrait_repro.cpp
@@ -510,7 +510,14 @@ void InitD3D11(void)
              },
             .BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT,
             .BufferCount = 2,								// Needs to be >= 2 for FLIP swap effect
-            .Scaling = DXGI_SCALING_NONE,
+            .Scaling = DXGI_SCALING_STRETCH,
+
+                    // TODO: If we ever get internal rotation happening, we can go back to DXGI_SCALING_NONE without cause for concern
+
+                    // DXGI_SCALING_STRETCH is the default, and gives us correct output in the presence of portrait orientation swapchains
+                    // DXGI_SCALING_NONE has odd and IMHO undocumented or otherwise erroneous behaviour relating to portrait orientation fullscreen swapchains
+                    // DXGI_SCALING_ASPECT_RATIO_STRETCH is not supported with CreateSwapChainForHwnd
+
             .SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD,	// DXGI_SWAP_EFFECT_FLIP_DISCARD, DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL
             .Flags = swapchain_flags,
         };


### PR DESCRIPTION
This pull request demonstrates a fix for the issue this entire repository was created.

It is unclear why this resolves the issue. The effect of `DXGI_SCALING_NONE` here seems counter intuitive, while `DXGI_SCALING_STRETCH` would imply behaviour that we do not want. Particularly since there is no mention of this possible footgun in any DXGI documentation.

In particular..

[DXGI overview : Using a rotated monitor](https://learn.microsoft.com/en-us/windows/win32/direct3ddxgi/d3d10-graphics-programming-guide-dxgi#using-a-rotated-monitor)

> Using a rotated monitor
An application **does not need to worry about** monitor orientation, DXGI will rotate a swap-chain buffer during presentation, if necessary.


Here's the [documentation ](https://learn.microsoft.com/en-us/windows/win32/api/dxgi1_2/ne-dxgi1_2-dxgi_scaling)on the Scaling mode enumerations:

> DXGI_SCALING_STRETCH
> 
> Directs DXGI to make the back-buffer contents scale to fit the presentation target size. This is the implicit behavior of DXGI when you call the IDXGIFactory::CreateSwapChain method.
> 
> DXGI_SCALING_NONE
> 
> Directs DXGI to make the back-buffer contents appear without any scaling when the presentation target size is not equal to the back-buffer size. The top edges of the back buffer and presentation target are aligned together. If the WS_EX_LAYOUTRTL style is associated with the HWND handle to the target output window, the right edges of the back buffer and presentation target are aligned together; otherwise, the left edges are aligned together. All target area outside the back buffer is filled with window background color.
> 
>   This value specifies that all target areas outside the back buffer of a swap chain are filled with the background color that you specify in a call to IDXGISwapChain1::SetBackgroundColor.



All in all this is very much feeling like a DXGI or possible DWM issue.
It's possible this is simply intended though undocumented behaviour, I can't say. I've not had an opportunity to validate on any other system or if the issue is local to some specific combination of hardware/configuration

Curiously enough, this issue does *NOT* present in the DX12 project. It appears to be only present against DX11 (presumably because we're much more explicit about swapchain image transition behaviour)